### PR TITLE
Bump haproxy version to 2.6.11

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,7 @@
-haproxy/haproxy-2.6.9.tar.gz:
-  size: 4045208
-  object_id: dce2e08a-c663-4571-7026-bb5f365da724
-  sha: sha256:f01a1c5f465dc1b5cd175d0b28b98beb4dfe82b5b5b63ddcc68d1df433641701
+haproxy/haproxy-2.6.11.tar.gz:
+  size: 4060392
+  object_id: 2e3deb6e-88dc-4874-47ff-76fee1c1e0b3
+  sha: sha256:e0bc430ac407747b077bc88ee6922b4616fa55a9e0f3ec84438dfb055eb9a715
 haproxy/hatop-0.8.2:
   size: 74157
   object_id: 00125e3f-bdaa-4da3-583f-b680b0b30df4

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -8,7 +8,7 @@ PCRE_VERSION=10.42  # https://github.com/PCRE2Project/pcre2/releases/download/pc
 
 SOCAT_VERSION=1.7.4.4  # http://www.dest-unreach.org/socat/download/socat-1.7.4.4.tar.gz
 
-HAPROXY_VERSION=2.6.9  # https://www.haproxy.org/download/2.6/src/haproxy-2.6.9.tar.gz
+HAPROXY_VERSION=2.6.11  # https://www.haproxy.org/download/2.6/src/haproxy-2.6.11.tar.gz
 
 HATOP_VERSION=0.8.2  # https://github.com/jhunt/hatop/releases/download/v0.8.2/hatop
 


### PR DESCRIPTION

Automatic bump from version 2.6.9 to version 2.6.11, downloaded from https://www.haproxy.org/download/2.6/src/haproxy-2.6.11.tar.gz.

After merge, consider releasing a new version of haproxy-boshrelease.
